### PR TITLE
[#119] Add friends list empty component

### DIFF
--- a/src/components/friendsList/FriendsList.js
+++ b/src/components/friendsList/FriendsList.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { List, Avatar } from 'antd/lib/index';
+import { List, Avatar } from 'antd';
+import FriendsEmpty from './friendsEmpty';
 import './FriendsList.css';
 
 const FriendsList = ({ friends, FriendsButton }) => {
+  if (!friends.length) {
+    return <FriendsEmpty />;
+  }
+
   return (
     <div className="friends-list">
       <List

--- a/src/components/friendsList/friendsEmpty/FriendsEmpty.css
+++ b/src/components/friendsList/friendsEmpty/FriendsEmpty.css
@@ -1,0 +1,3 @@
+.friends-empty {
+  margin: 90px 0;
+}

--- a/src/components/friendsList/friendsEmpty/FriendsEmpty.js
+++ b/src/components/friendsList/friendsEmpty/FriendsEmpty.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Empty } from 'antd';
+import './FriendsEmpty.css';
+
+const FriendsEmpty = ({ message }) => (
+  <div className="friends-empty">
+    <Empty
+      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      imageStyle={{
+        marginBottom: '20px',
+      }}
+      description={message}
+    />
+  </div>
+);
+
+FriendsEmpty.defaultProps = {
+  message: '새로운 요청이 없습니다.'
+};
+
+FriendsEmpty.propTypes = {
+  message: PropTypes.string,
+};
+
+export default FriendsEmpty;

--- a/src/components/friendsList/friendsEmpty/index.js
+++ b/src/components/friendsList/friendsEmpty/index.js
@@ -1,0 +1,1 @@
+export { default } from './FriendsEmpty';

--- a/src/components/myFriendsList/MyFriendsList.js
+++ b/src/components/myFriendsList/MyFriendsList.js
@@ -35,13 +35,12 @@ class MyFriendsList extends Component {
 }
 
 MyFriendsList.defaultProps = {
-  friends: [],
+  searchedMyFriends: [],
 };
 
 MyFriendsList.propTypes = {
   getFriends: PropTypes.func.isRequired,
   handleFriendSearchInputChange: PropTypes.func.isRequired,
-  friends: PropTypes.array,
   searchedMyFriends: PropTypes.array,
 };
 

--- a/src/pages/friends/FriendsPage.css
+++ b/src/pages/friends/FriendsPage.css
@@ -6,3 +6,7 @@
 .friends-list-col {
   padding: 15px;
 }
+
+.friends-page .ant-tabs-bar {
+  margin: 0 0 -16px 0;
+}

--- a/src/pages/friends/FriendsPage.js
+++ b/src/pages/friends/FriendsPage.js
@@ -1,20 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { FriendsList, MyFriendsList } from 'components';
-import { Tabs, Icon } from 'antd';
 import {
-  FriendActionTypes,
   FriendActionCreators,
 } from 'store/friends/friend.action';
-import FriendSelector from 'store/friends/friend.select';
 
-import ReceiveFriendButton from './receiveFriendsButton';
-import RequestFriendsButton from './requestFriendsButton';
-import RecommendFriendsButton from './recommendFriendsButton';
+import FriendsPageComponent from './FriendsPageComponent';
 import './FriendsPage.css';
-
-const { TabPane } = Tabs;
 
 class FriendsPage extends Component {
   componentDidMount() {
@@ -30,74 +22,8 @@ class FriendsPage extends Component {
   }
 
   render() {
-    const {
-      friendRequestsReceive,
-      friendRequestsSend,
-      recommendFriends,
-    } = this.props;
-
     return (
-      <div className="friends-page ant-row">
-        <div className="ant-col ant-col-12">
-          <h2>대기중인 친구신청</h2>
-          <Tabs>
-            <TabPane
-              tab={
-                <span>
-                  <Icon type="user-add" />
-                  받은 신청
-                </span>
-              }
-              key="1"
-            >
-              <div className="friends-list-col">
-                <FriendsList
-                  friends={friendRequestsReceive}
-                  FriendsButton={ReceiveFriendButton}
-                />
-              </div>
-            </TabPane>
-            <TabPane
-              tab={
-                <span>
-                  <Icon type="user" />
-                  보낸 신청
-                </span>
-              }
-              key="2"
-            >
-              <div className="friends-list-col">
-                <FriendsList
-                  friends={friendRequestsSend}
-                  FriendsButton={RequestFriendsButton}
-                />
-              </div>
-            </TabPane>
-            <TabPane
-              tab={
-                <span>
-                  <Icon type="user" />
-                  추천 친구
-                </span>
-              }
-              key="3"
-            >
-              <div className="friends-list-col">
-                <FriendsList
-                  friends={recommendFriends}
-                  FriendsButton={RecommendFriendsButton}
-                />
-              </div>
-            </TabPane>
-          </Tabs>
-        </div>
-        <div className="ant-col ant-col-12">
-          <h2>내 친구 목록</h2>
-          <div className="friends-list-col">
-            <MyFriendsList />
-          </div>
-        </div>
-      </div>
+      <FriendsPageComponent {...this.props} />
     );
   }
 }
@@ -112,7 +38,7 @@ FriendsPage.propTypes = {
   getRecommendFriends: PropTypes.func.isRequired,
 };
 
-const mapStatetoProps = state => ({
+const mapStateToProps = state => ({
   friendRequestsReceive: state.friend.friendRequestsReceive,
   friendRequestsSend: state.friend.friendRequestsSend,
   recommendFriends: state.friend.recommendFriends,
@@ -127,6 +53,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default connect(
-  mapStatetoProps,
+  mapStateToProps,
   mapDispatchToProps,
 )(FriendsPage);

--- a/src/pages/friends/FriendsPageComponent.js
+++ b/src/pages/friends/FriendsPageComponent.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon, Tabs } from 'antd';
+import { FriendsList, MyFriendsList } from 'components';
+import ReceiveFriendButton from './receiveFriendsButton';
+import RequestFriendsButton from './requestFriendsButton';
+import RecommendFriendsButton from './recommendFriendsButton';
+
+const { TabPane } = Tabs;
+
+const TabIcon = ({ icon, title }) => {
+  return (
+    <span>
+      <Icon type={icon} />
+      {title}
+    </span>
+  );
+};
+
+const FriendsPageComponent = (props) => {
+  const {
+    friendRequestsReceive,
+    friendRequestsSend,
+    recommendFriends,
+  } = props;
+
+  return (
+    <div className="friends-page ant-row">
+      <div className="ant-col ant-col-12">
+        <h2>대기중인 친구신청</h2>
+        <Tabs>
+          <TabPane tab={<TabIcon icon="user-add" title="받은 신청" />} key="1">
+            <div className="friends-list-col">
+              <FriendsList
+                friends={friendRequestsReceive}
+                FriendsButton={ReceiveFriendButton}
+              />
+            </div>
+          </TabPane>
+          <TabPane tab={<TabIcon icon="user" title="보낸 신청" />} key="2">
+            <div className="friends-list-col">
+              <FriendsList
+                friends={friendRequestsSend}
+                FriendsButton={RequestFriendsButton}
+              />
+            </div>
+          </TabPane>
+          <TabPane tab={<TabIcon icon="user" title="추천 친구" />} key="3">
+            <div className="friends-list-col">
+              <FriendsList
+                friends={recommendFriends}
+                FriendsButton={RecommendFriendsButton}
+              />
+            </div>
+          </TabPane>
+        </Tabs>
+      </div>
+      <div className="ant-col ant-col-12">
+        <h2>내 친구 목록</h2>
+        <div className="friends-list-col">
+          <MyFriendsList />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+TabIcon.propTypes = {
+  icon: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+FriendsPageComponent.propTypes = {
+  friendRequestsReceive: PropTypes.array.isRequired,
+  friendRequestsSend: PropTypes.array.isRequired,
+  recommendFriends: PropTypes.array.isRequired,
+};
+
+export default FriendsPageComponent;

--- a/src/pages/friends/recommendFriendsButton/RecommendFriendsButton.js
+++ b/src/pages/friends/recommendFriendsButton/RecommendFriendsButton.js
@@ -25,13 +25,13 @@ RecommendFriendsButton.propTypes = {
   createFriendsRequest: PropTypes.func.isRequired,
 };
 
-const mapStatetoProps = () => ({});
+const mapStateToProps = () => ({});
 const mapDispatchToProps = dispatch => ({
   createFriendsRequest: friendInfo => e =>
     dispatch(FriendActionCreators.createFriendsRequest(friendInfo)),
 });
 
 export default connect(
-  mapStatetoProps,
+  mapStateToProps,
   mapDispatchToProps,
 )(RecommendFriendsButton);


### PR DESCRIPTION
- FriendsEmpty 컴포넌트 추가
- 친구 목록이 없을 때, FriendsEmpty 컴포넌트를 렌더링
- css : 요청 목록 TabPane과 list 사이 간격 조절
- FriendsPage를 FriendsPageComponent로 view 분리
- RecommendFriendsButton의 변수명 오타 수정